### PR TITLE
Full `⊑` implementation

### DIFF
--- a/src/APL/Indexer.java
+++ b/src/APL/Indexer.java
@@ -185,6 +185,29 @@ public final class Indexer implements Iterable<int[]>, Iterator<int[]> {
     }
   }
   
+  // v is an index vector
+  // checks for rank & bound errors and returns a ravel index
+  public static int vec(Value v, int[] ish, Callable blame) {
+    if (ish.length!=v.ia) throw new LengthError(blame+": amount of index parts should equal rank ("+v.ia+" index parts, shape ≡ "+Main.formatAPL(ish)+")", blame);
+    if (v.rank != 1) throw new RankError(blame+": rank of indices must be 1 (shape ≡ "+Main.formatAPL(v.shape)+")", blame);
+    int ind = 0;
+    for (int i = 0; i < v.ia; i++) {
+      Value c = v.get(i);
+      if (!(c instanceof Primitive)) throw new DomainError(blame+": index must consist of integers", blame);
+      int n = c.asInt();
+      if (n<0 || n>=ish[i]) throw new LengthError(blame+": indexing out-of-bounds (shape ≡ "+Main.formatAPL(ish)+"; pos["+i+"] ≡ "+c+")", blame);
+      ind = ish[i]*ind + n;
+    }
+    return ind;
+  }
+
+  // same, with scalar index into vector
+  public static int scal(int n, int[] ish, Callable blame) {
+    if (ish.length!=1) throw new LengthError(blame+": amount of index parts should equal rank (scalar index, shape ≡ "+Main.formatAPL(ish)+")", blame);
+    if (n<0 || n>=ish[0]) throw new LengthError(blame+": indexing out-of-bounds (shape ≡ "+Main.formatAPL(ish)+"; pos["+0+"] ≡ "+n+")", blame);
+    return n;
+  }
+  
   public Iterator<int[]> iterator() {
     return this;
   }

--- a/src/APL/types/functions/builtins/fns2/LBoxUBBuiltin.java
+++ b/src/APL/types/functions/builtins/fns2/LBoxUBBuiltin.java
@@ -74,7 +74,7 @@ public class LBoxUBBuiltin extends Builtin {
   
   
   public Value underW(Obj o, Value a, Value w) {
-    Value v = o instanceof Fun? ((Fun) o).call(call(a, w)) : (Value) o;
+    Value v = (Value) o;
     Value[] vs = w.valuesCopy();
     if (a instanceof Primitive) {
       vs[Indexer.scal(a.asInt(), w.shape, this)] = v;


### PR DESCRIPTION
Allows you to use `_amend  ← {𝕨⌾(𝕗⊑⊢)𝕩}` for the reference implementations without boxing `𝕨`.