### PR TITLE
Support for #! scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 out
 src/build
 .idea
-APL.jar
-APL.iml
+BQN.jar
+BQN.iml
 app/APL/src/
 app/build/
 app/APLApp/android/

--- a/APL
+++ b/APL
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-java -jar APL.jar "$@"

--- a/BQN
+++ b/BQN
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+java -jar BQN.jar "$@"

--- a/src/APL/Main.java
+++ b/src/APL/Main.java
@@ -70,7 +70,7 @@ public class Main {
                 switch (c) {
                   case 'f':
                     String name = args[++i];
-                    exec(readFile(name), global);
+                    exec(removeHashBang(readFile(name)), global);
                     break;
                   case '•':
                     throw new DomainError("• settings must be a separate argument");
@@ -285,6 +285,12 @@ public class Main {
       ne.initCause(e);
       throw ne;
     }
+  }
+  static String removeHashBang(String source) {
+    if (source.charAt(0)=='#' && source.charAt(1)=='!') {
+      source = source.substring(source.indexOf('\n')+1);
+    }
+    return source;
   }
   
   public static Value exec(String s, Scope sc) {


### PR DESCRIPTION
Little changes to get #! scripting up. Since `BQN` can only be used from the repository itself, I have a `dbqn` executable in `~/bin` containing

    #!/bin/bash
    
    java -jar /home/marshall/Clone/dbqn/BQN.jar -f "$@"