### PR TITLE
Fix up problems with empty left argument in Select and Copy

### DIFF
--- a/src/APL/types/functions/builtins/fns2/LBoxBuiltin.java
+++ b/src/APL/types/functions/builtins/fns2/LBoxBuiltin.java
@@ -31,10 +31,12 @@ public class LBoxBuiltin extends Builtin {
   
     int ar = a.shape.length;
     int wr = w.shape.length;
-    if (a.ia==0 || a.get(0) instanceof Num) {
-      // int[] sh = new int[ar+wr-1];
-      // System.arraycopy(a.shape, 0, sh, 0, ar);
-      // System.arraycopy(w.shape, 1, sh, ar, wr -1);
+    if (a.ia==0) {
+      int[] sh = new int[ar+wr-1];
+      System.arraycopy(a.shape, 0, sh, 0, ar);
+      System.arraycopy(w.shape, 1, sh, ar, wr -1);
+      return Arr.create(new Value[0], sh);
+    } else if (a.get(0) instanceof Num) {
       double[] ds = a.asDoubleArr();
       Value[] res = new Value[ds.length];
       for (int i = 0; i < ds.length; i++) res[i] = getCell(Num.toInt(ds[i]), w, this);

--- a/src/APL/types/functions/builtins/fns2/SlashBuiltin.java
+++ b/src/APL/types/functions/builtins/fns2/SlashBuiltin.java
@@ -104,7 +104,9 @@ public class SlashBuiltin extends Builtin {
     if (x.rank==0) throw new RankError(blame+": 𝕩 cannot be scalar", blame, x);
     int depth = MatchBuiltin.full(w);
     int[][] am; // scalars are represented as 1-item int[]s
-    if (depth <= 1) {
+    if (w.ia == 0) {
+      return x;
+    } else if (depth <= 1) {
       am = new int[1][];
       am[0] = w.asIntVec();
       if (w.rank==1 && am[0].length!=x.shape[0]) throw new LengthError(blame+": wrong replicate length (length ≡ "+am[0].length+", shape ≡ "+Main.formatAPL(x.shape)+")", blame);


### PR DESCRIPTION
There were some test failures here: Copy should always accept an empty left argument as a no-op (0 axes) rather than checking for a length error, and Select wasn't getting the shape right because mixing no cells loses shape information.