### PR TITLE
build{,8}: pass -encoding UTF-8 to javac

### DIFF
--- a/build
+++ b/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 rm -f BQN.jar
 mkdir -p classes
-javac -d ./classes $(find src -name '*.java')
+javac -encoding UTF-8 -d ./classes $(find src -name '*.java')
 cd classes
 jar cvfe BQN.jar BQN.Main * > /dev/null
 mv BQN.jar ../BQN.jar

--- a/build8
+++ b/build8
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 rm -f BQN.jar
 mkdir -p classes
-javac --release 8 -d ./classes $(find src -name '*.java') || echo "Note: ./build8 can only be run in Java 9 and later. Use ./build on java 8"
+javac --release 8 -encoding UTF-8 -d ./classes $(find src -name '*.java') || echo "Note: ./build8 can only be run in Java 9 and later. Use ./build on java 8"
 cd classes
 jar cvfe BQN.jar BQN.Main * > /dev/null
 mv BQN.jar ../BQN.jar

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ java -jar /path/to/dzaima/BQN/BQN.jar -f "$@"
 With GraalVM's Native Image, you can build a complete binary (≈10MB, doesn't need Java at all, startup time <10ms):
 
 ```bash
-native-image --report-unsupported-elements-at-runtime -jar BQN.jar nBQN
+native-image --report-unsupported-elements-at-runtime -J-Dfile.encoding=UTF-8 -jar BQN.jar nBQN
 ```
 This generates a regular executable file `nBQN`, usable in place of `java -jar BQN.jar`. Note that this also disables compilation to Java bytecode, and has different performance characteristics to a regular JVM.
 


### PR DESCRIPTION
By default, javac uses the locale (or equivalent mechanism on other
system) to determine the encoding to use for source files. Passing
-encoding overrides that mechanism and allows building BQN even with the
default locale (C) which is used e. g. in the nixpkgs build sandbox.

Encoding problems can still occur at runtime. For GraalVM there's an
easy fix, I haven't found a better one than setting `LANG` for running
the jar yet.